### PR TITLE
Add segments for C64 specific headers. Fix kernal routine for printing.

### DIFF
--- a/ldscripts/c64.cfg
+++ b/ldscripts/c64.cfg
@@ -1,9 +1,13 @@
 MEMORY {
-ZP:  start = $0000, size = $0070, type = rw, define = yes;
-RAM: start = $0200, size = $fd00, file = %O, define = yes;
+ZP:  start = $0002, size = $0070, type = rw, define = yes;
+LOADADDR: start = $07ff, size = $2, file = %O;
+EXEHDR: start = $0801, size = $0c, file = %O;
+RAM: start = $080d, size = $cfff-$0801, file = %O, define = yes;
 }
 SEGMENTS {
-STARTUP:  load = RAM, type = ro;
+LOADADDR: load = LOADADDR, type = ro;
+EXEHDR:   load = EXEHDR, type = ro;
+STARTUP:  load = RAM, type = ro, define = yes;
 LOWCODE:  load = RAM, type = ro,               optional = yes;
 INIT:     load = RAM, type = ro, define = yes, optional = yes;
 CODE:     load = RAM, type = ro;
@@ -28,7 +32,7 @@ label = __INTERRUPTOR_TABLE__,
 count = __INTERRUPTOR_COUNT__;
 }
 SYMBOLS {
-__STACKTOP__: type = weak, value = $ffff;
+__STACKTOP__: type = weak, value = $cfff;
 }
 
 

--- a/libtinyc/c64/fputc.c
+++ b/libtinyc/c64/fputc.c
@@ -3,7 +3,6 @@
 int fputc (int c, FILE *f)
 {
   register char x asm ("a") = c;
-  /* FIXME: I don't know how to do this on a C64!  */
   __asm__ __volatile__ ("jsr $ffd2" : : "Aq" (x));
 
   return c;

--- a/libtinyc/c64/fputc.c
+++ b/libtinyc/c64/fputc.c
@@ -4,7 +4,7 @@ int fputc (int c, FILE *f)
 {
   register char x asm ("a") = c;
   /* FIXME: I don't know how to do this on a C64!  */
-  __asm__ __volatile__ ("jsr $ffee" : : "Aq" (x));
+  __asm__ __volatile__ ("jsr $ffd2" : : "Aq" (x));
 
   return c;
 }


### PR DESCRIPTION
This is the second of two pull requests to create runnable binaries for the C64. In addition, I changed the memory areas a bit, as addresses 0 and 1 have a special purpose on the C64 and should not be used for variables. Also it seems to make things much easier if the stack is at $cfff, as addresses higher than this are shadowed by the kernal. 

In addition I fixed the call to the kernal CHROUT routine for fputc.
