### PR TITLE
Assembly implementation of memset (size optimized)

### DIFF
--- a/libtinyc/c64/fputc.c
+++ b/libtinyc/c64/fputc.c
@@ -3,7 +3,6 @@
 int fputc (int c, FILE *f)
 {
   register char x asm ("a") = c;
-  /* FIXME: I don't know how to do this on a C64!  */
   __asm__ __volatile__ ("jsr $ffd2" : : "Aq" (x));
 
   return c;

--- a/libtinyc/memset.c
+++ b/libtinyc/memset.c
@@ -3,12 +3,33 @@
 void *
 memset (void *s, int c, size_t n)
 {
-  int i;
   unsigned char cbyte = c;
   unsigned char *scp = s;
+  unsigned int nint = n;
   
-  for (i = 0; i < n; i++)
-    scp[i] = cbyte;
-  
+  __asm__ __volatile__ 
+    (
+    "ldy #0\n\t"
+    "ldx %2+1\n\t"
+    "beq :++\n\t"
+    ":\n\t"
+    "sta (%0),y\n\t"
+    "iny\n\t"
+    "bne :-\n\t"
+    "inc %0+1\n\t"
+    "dex\n\t"
+    "bne :-\n\t"
+    ":\n\t"
+    "ldy %2\n\t"
+    "beq :++\n\t"
+    ":\n\t"
+    "dey\n\t"
+    "sta (%0),y\n\t"
+    "bne :-\n\t"
+    ":\n\t"
+    :
+    : "Zp" (scp), "Aq" (cbyte), "Zp" (nint)
+    : "x", "y");
+
   return s;
 }


### PR DESCRIPTION
I did this assembly optimization mostly to learn how to do this in general. It does not hurt though and is smaller and faster than the C implementation. This depends on a new zeropage register class added in a second pull request to gcc-src.
